### PR TITLE
Fix @babel/runtime missing issue

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -90,6 +90,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0-beta.49",
     "@babel/preset-env": "^7.0.0-beta.49",
     "@babel/preset-stage-2": "^7.0.0-beta.49",
+    "@babel/runtime": "^7.0.0-beta.49",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-loader": "^8.0.0-beta.3",
     "babel-plugin-transform-vue-jsx": "^4.0.1",


### PR DESCRIPTION
CI saving `@babel/runtime` to workspace from unknown stage, it make all test passed but missing in new created project.